### PR TITLE
Add condition to process_int_transit application

### DIFF
--- a/INT-MD/int_md.p4
+++ b/INT-MD/int_md.p4
@@ -69,7 +69,9 @@ control MyEgress(inout headers hdr,
             standard_metadata.egress_global_timestamp = local_metadata.perserv_meta.egress_global_timestamp;
         }
 
-        process_int_transit.apply(hdr, local_metadata, standard_metadata);
+        if (standard_metadata.instance_type != CLONE_PKT) {
+            process_int_transit.apply(hdr, local_metadata, standard_metadata);
+        }
 
         // In case of cloned packet, send telemetry report
         if (standard_metadata.instance_type == CLONE_PKT) {


### PR DESCRIPTION
The correct logic is to only add transit metadata to the original packet, not the clone. The clone should just be used for reporting.


Very Thanks, I am using this for my course project